### PR TITLE
 BREAKING CHANGE: Move matrix functions into namespace

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -20,6 +20,9 @@ outputs. With the power of NumPy, the vectorized functions are fast.
 .. automodule:: vg
     :members:
 
+.. automodule:: vg.matrix
+    :members:
+
 .. automodule:: vg.shape
     :members:
 

--- a/vg/__init__.py
+++ b/vg/__init__.py
@@ -2,5 +2,6 @@ from .package_version import __version__
 from .core import *
 
 from . import core as _core
+from . import matrix
 from . import shape
-__all__ = _core.__all__ + ['shape']
+__all__ = _core.__all__ + ['matrix', 'shape']

--- a/vg/_helpers.py
+++ b/vg/_helpers.py
@@ -1,0 +1,16 @@
+def pluralize(noun, count):
+    return noun if count == 1 else "{}s".format(noun)
+
+
+def raise_dimension_error(*input_values):
+    messages = [
+        "{} {}".format(input_value.ndim, pluralize("dimension", input_value.ndim))
+        for input_value in input_values
+    ]
+    if len(messages) == 1:
+        message = messages[0]
+    elif len(messages) == 2:
+        message = "{} and {}".format(*messages)
+    else:
+        message = "those inputs"
+    raise ValueError("Not sure what to do with {}".format(message))

--- a/vg/core.py
+++ b/vg/core.py
@@ -1,5 +1,6 @@
 import math
 import numpy as np
+from ._helpers import pluralize, raise_dimension_error
 
 __all__ = [
     "normalize",
@@ -14,34 +15,12 @@ __all__ = [
     "rotate",
     "almost_zero",
     "almost_collinear",
-    "pad_with_ones",
-    "unpad",
-    "apply_homogeneous",
     "principal_components",
     "major_axis",
     "apex",
     "farthest",
     "basis",
 ]
-
-
-def pluralize(noun, count):
-    return noun if count == 1 else "{}s".format(noun)
-
-
-def raise_dimension_error(*input_values):
-    messages = [
-        "{} {}".format(input_value.ndim, pluralize("dimension", input_value.ndim))
-        for input_value in input_values
-    ]
-    if len(messages) == 1:
-        message = messages[0]
-    elif len(messages) == 2:
-        message = "{} and {}".format(*messages)
-    else:
-        message = "those inputs"
-    raise ValueError("Not sure what to do with {}".format(message))
-
 
 def normalize(vector):
     """
@@ -341,65 +320,6 @@ def almost_collinear(v1, v2, atol=1e-08):
     cross = np.cross(v1, v2)
     norm = np.linalg.norm(cross)
     return np.isclose(norm, 0.0, rtol=0, atol=atol)
-
-
-def pad_with_ones(matrix):
-    """
-    Add a column of ones. Transform from:
-        array([[1., 2., 3.],
-               [2., 3., 4.],
-               [5., 6., 7.]])
-    to:
-        array([[1., 2., 3., 1.],
-               [2., 3., 4., 1.],
-               [5., 6., 7., 1.]])
-
-    """
-    if matrix.ndim != 2 or matrix.shape[1] != 3:
-        raise ValueError("Invalid shape %s: pad expects nx3" % (matrix.shape,))
-    return np.pad(matrix, ((0, 0), (0, 1)), mode="constant", constant_values=1)
-
-
-def unpad(matrix):
-    """
-    Strip off a column (e.g. of ones). Transform from:
-        array([[1., 2., 3., 1.],
-               [2., 3., 4., 1.],
-               [5., 6., 7., 1.]])
-    to:
-        array([[1., 2., 3.],
-               [2., 3., 4.],
-               [5., 6., 7.]])
-
-    """
-    if matrix.ndim != 2 or matrix.shape[1] != 4:
-        raise ValueError("Invalid shape %s: unpad expects nx4" % (matrix.shape,))
-    if not all(matrix[:, 3] == 1.0):
-        raise ValueError("Expected a column of ones")
-    return np.delete(matrix, 3, axis=1)
-
-
-def apply_homogeneous(vertices, transform):
-    """
-    Apply the given transformation matrix to the vertices using homogenous
-    coordinates.
-    """
-    if transform.shape != (4, 4):
-        raise ValueError("Transformation matrix should be 4x4")
-
-    if vertices.ndim == 1:
-        matrix = vertices[np.newaxis]
-    elif vertices.ndim == 2:
-        matrix = vertices
-    else:
-        raise_dimension_error(vertices)
-
-    if matrix.shape[1] != 3:
-        raise ValueError("Vertices should be 3x1 or Nx3")
-
-    result = unpad(np.dot(transform, pad_with_ones(matrix).T).T)
-    return result[0] if vertices.ndim == 1 else result
-
 
 def principal_components(coords):
     """

--- a/vg/core.py
+++ b/vg/core.py
@@ -1,6 +1,6 @@
 import math
 import numpy as np
-from ._helpers import pluralize, raise_dimension_error
+from ._helpers import raise_dimension_error
 
 __all__ = [
     "normalize",

--- a/vg/core.py
+++ b/vg/core.py
@@ -22,6 +22,7 @@ __all__ = [
     "basis",
 ]
 
+
 def normalize(vector):
     """
     Return the vector, normalized.
@@ -320,6 +321,7 @@ def almost_collinear(v1, v2, atol=1e-08):
     cross = np.cross(v1, v2)
     norm = np.linalg.norm(cross)
     return np.isclose(norm, 0.0, rtol=0, atol=atol)
+
 
 def principal_components(coords):
     """

--- a/vg/matrix.py
+++ b/vg/matrix.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ._helpers import raise_dimension_error
 
+
 def pad_with_ones(matrix):
     """
     Add a column of ones. Transform from:

--- a/vg/matrix.py
+++ b/vg/matrix.py
@@ -1,0 +1,59 @@
+import numpy as np
+from ._helpers import raise_dimension_error
+
+def pad_with_ones(matrix):
+    """
+    Add a column of ones. Transform from:
+        array([[1., 2., 3.],
+               [2., 3., 4.],
+               [5., 6., 7.]])
+    to:
+        array([[1., 2., 3., 1.],
+               [2., 3., 4., 1.],
+               [5., 6., 7., 1.]])
+
+    """
+    if matrix.ndim != 2 or matrix.shape[1] != 3:
+        raise ValueError("Invalid shape %s: pad expects nx3" % (matrix.shape,))
+    return np.pad(matrix, ((0, 0), (0, 1)), mode="constant", constant_values=1)
+
+
+def unpad(matrix):
+    """
+    Strip off a column (e.g. of ones). Transform from:
+        array([[1., 2., 3., 1.],
+               [2., 3., 4., 1.],
+               [5., 6., 7., 1.]])
+    to:
+        array([[1., 2., 3.],
+               [2., 3., 4.],
+               [5., 6., 7.]])
+
+    """
+    if matrix.ndim != 2 or matrix.shape[1] != 4:
+        raise ValueError("Invalid shape %s: unpad expects nx4" % (matrix.shape,))
+    if not all(matrix[:, 3] == 1.0):
+        raise ValueError("Expected a column of ones")
+    return np.delete(matrix, 3, axis=1)
+
+
+def transform(vertices, transform):
+    """
+    Apply the given transformation matrix to the vertices using homogenous
+    coordinates.
+    """
+    if transform.shape != (4, 4):
+        raise ValueError("Transformation matrix should be 4x4")
+
+    if vertices.ndim == 1:
+        matrix = vertices[np.newaxis]
+    elif vertices.ndim == 2:
+        matrix = vertices
+    else:
+        raise_dimension_error(vertices)
+
+    if matrix.shape[1] != 3:
+        raise ValueError("Vertices should be 3x1 or Nx3")
+
+    result = unpad(np.dot(transform, pad_with_ones(matrix).T).T)
+    return result[0] if vertices.ndim == 1 else result

--- a/vg/test_matrix_pad_with_ones.py
+++ b/vg/test_matrix_pad_with_ones.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pytest
-from . import core as vg
+from .matrix import pad_with_ones
 
 
 def test_pad_with_ones():
     np.testing.assert_array_equal(
-        vg.pad_with_ones(np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]])),
+        pad_with_ones(np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]])),
         np.array([[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 1.0]]),
     )
 
@@ -15,11 +15,11 @@ def test_pad_with_wrong_dimensions():
     with pytest.raises(
         ValueError, match=r"^Invalid shape \(3L?, 4L?\): pad expects nx3$"
     ):
-        vg.pad_with_ones(
+        pad_with_ones(
             np.array(
                 [[1.0, 2.0, 3.0, 42.0], [2.0, 3.0, 4.0, 42.0], [5.0, 6.0, 7.0, 42.0]]
             )
         )
 
     with pytest.raises(ValueError, match=r"^Invalid shape \(3L?,\): pad expects nx3$"):
-        vg.pad_with_ones(np.array([1.0, 2.0, 3.0]))
+        pad_with_ones(np.array([1.0, 2.0, 3.0]))

--- a/vg/test_matrix_transform.py
+++ b/vg/test_matrix_transform.py
@@ -16,17 +16,13 @@ transform = np.array(
 def test_apply_homogeneous():
     point = np.array([5.0, 0.0, 1.0])
     expected_point = np.array([15.0, 0.0, 2.0])
-    np.testing.assert_array_equal(
-        apply_transform(point, transform), expected_point
-    )
+    np.testing.assert_array_equal(apply_transform(point, transform), expected_point)
 
 
 def test_apply_homogeneous_stacked():
     points = np.array([[1.0, 2.0, 3.0], [5.0, 0.0, 1.0]])
     expected_points = np.array([[3.0, 1.0, 6.0], [15.0, 0.0, 2.0]])
-    np.testing.assert_array_equal(
-        apply_transform(points, transform), expected_points
-    )
+    np.testing.assert_array_equal(apply_transform(points, transform), expected_points)
 
 
 def test_apply_homogeneous_error():

--- a/vg/test_matrix_transform.py
+++ b/vg/test_matrix_transform.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from . import core as vg
+from .matrix import transform as apply_transform
 
 scale_factor = np.array([3.0, 0.5, 2.0])
 transform = np.array(
@@ -17,7 +17,7 @@ def test_apply_homogeneous():
     point = np.array([5.0, 0.0, 1.0])
     expected_point = np.array([15.0, 0.0, 2.0])
     np.testing.assert_array_equal(
-        vg.apply_homogeneous(point, transform), expected_point
+        apply_transform(point, transform), expected_point
     )
 
 
@@ -25,14 +25,14 @@ def test_apply_homogeneous_stacked():
     points = np.array([[1.0, 2.0, 3.0], [5.0, 0.0, 1.0]])
     expected_points = np.array([[3.0, 1.0, 6.0], [15.0, 0.0, 2.0]])
     np.testing.assert_array_equal(
-        vg.apply_homogeneous(points, transform), expected_points
+        apply_transform(points, transform), expected_points
     )
 
 
 def test_apply_homogeneous_error():
     with pytest.raises(ValueError, match="Transformation matrix should be 4x4"):
-        vg.apply_homogeneous(np.array([1.0, 2.0, 3.0]), np.array([1.0]))
+        apply_transform(np.array([1.0, 2.0, 3.0]), np.array([1.0]))
     with pytest.raises(ValueError, match="Vertices should be 3x1 or Nx3"):
-        vg.apply_homogeneous(np.array([1.0, 2.0]), transform)
+        apply_transform(np.array([1.0, 2.0]), transform)
     with pytest.raises(ValueError, match="Not sure what to do with 3 dimensions"):
-        vg.apply_homogeneous(np.array([[[1.0, 2.0, 3.0]]]), transform)
+        apply_transform(np.array([[[1.0, 2.0, 3.0]]]), transform)

--- a/vg/test_matrix_unpad.py
+++ b/vg/test_matrix_unpad.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pytest
-from . import core as vg
+from .matrix import unpad
 
 
 def test_unpad():
     np.testing.assert_array_equal(
-        vg.unpad(
+        unpad(
             np.array([[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 1.0]])
         ),
         np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
@@ -15,14 +15,14 @@ def test_unpad():
     with pytest.raises(
         ValueError, match=r"^Invalid shape \(3L?, 3L?\): unpad expects nx4$"
     ):
-        vg.unpad(np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]))
+        unpad(np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]))
 
     with pytest.raises(
         ValueError, match=r"^Invalid shape \(4L?,\): unpad expects nx4$"
     ):
-        vg.unpad(np.array([1.0, 2.0, 3.0, 4.0]))
+        unpad(np.array([1.0, 2.0, 3.0, 4.0]))
 
     with pytest.raises(ValueError, match="Expected a column of ones"):
-        vg.unpad(
+        unpad(
             np.array([[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 3.0]])
         )


### PR DESCRIPTION
- `vg.pad_with_ones()` -> `vg.matrix.pad_with_ones()`
- `vg.unpad()` -> `vg.matrix.unpad()`
- `vg.apply_homogeneous()` -> `vg.matrix.transform()`