### PR TITLE
Stop publishing wheels for Python 2

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -76,7 +76,6 @@ def doc_open():
 def publish():
     execute("rm -rf dist/")
     execute("python3 setup.py sdist bdist_wheel")
-    execute("python2 setup.py bdist_wheel")
     execute("twine upload dist/*")
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
         "Topic :: Scientific/Engineering :: Visualization",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
     ],
 )


### PR DESCRIPTION
The Python 2 wheels cannot be published to PyPI:

HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/


Related: di/markdown-description-example#4