### PR TITLE
Clarify what goes in vg vs polliwog

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ vg
 [![docs build](https://img.shields.io/readthedocs/vgpy.svg?style=flat-square)][docs build]
 [![code style](https://img.shields.io/badge/code%20style-black-black.svg?style=flat-square)][black]
 
-A **v**ery **g**ood vector-geometry and linear-algebra toolbelt. Linear
-algebra for humans. Simple [NumPy][] operations made readable, built to
-scale from prototyping to production.
+A **v**ery **g**ood vector-geometry toolbelt for dealing with 3D points and
+vectors. These are simple [NumPy][] operations made readable, built to scale
+from prototyping to production.
 
 See the complete API reference: https://vgpy.readthedocs.io/en/latest/
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,7 +1,8 @@
 vg
 ==
 
-**vg** is a **v**ery **g**ood vector-geometry and linear-algebra toolbelt.
+**vg** is a **v**ery **g**ood vector-geometry toolbelt for dealing with 3D
+points and vectors.
 
 Motivation
 ----------
@@ -117,3 +118,28 @@ Versioning
 This library adheres to [Semantic Versioning][semver].
 
 [semver]: https://semver.org/
+
+
+If you like vg you might also like &hellip;
+-------------------------------------------
+
+### [polliwog][]
+
+Polliwog is a 2D and 3D computational geometry library. Like vg, it's designed
+to scale from prototyping to production. It includes vectorized geometric
+operations, transforms, and primitives like planes, polygonal chains, and
+axis-aligned bounding boxes. Implemented in pure Python/NumPy. It is depends on
+vg and is lightweight and fast.
+
+*Note:* vg is limited in scope to dealing with 3D points and vectors. Almost
+anything more complicated is considered general computational geometry, and goes
+in polliwog instead.
+
+### [ounce][]
+
+Fast, simple, non-fancy, and non-magical package for manipulating units of
+measure. A faster and less fancy counterpart to [Pint][].
+
+[polliwog]: https://polliwog.readthedocs.io/en/latest/
+[ounce]: https://ounce.readthedocs.io/en/latest/
+[pint]: https://pint.readthedocs.io/en/stable/

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = ["numpy"]
 setup(
     name="vg",
     version=version_info["__version__"],
-    description="Linear algebra for humans: a very good vector-geometry and linear-algebra toolbelt",
+    description="A vector-geometry toolbelt for dealing with 3D points and vectors",
     long_description=readme,
     long_description_content_type="text/markdown",
     author="Metabolize, Body Labs, and other contributors",

--- a/vg/matrix.py
+++ b/vg/matrix.py
@@ -61,7 +61,7 @@ def unpad(matrix):
 def transform(vertices, transform):
     """
     Deprecated. Will be removed in vg 2. Use
-    `polliwog.transform.apply_affine_transform()` instead.
+    `polliwog.transform.apply_transform()` instead.
 
     Apply the given transformation matrix to the vertices using homogenous
     coordinates.
@@ -70,7 +70,7 @@ def transform(vertices, transform):
 
     warnings.warn(
         "`vg.matrix.transform()` has been deprecated and will be removed in vg 2. "
-        + "Use `polliwog.transform.apply_affine_transform()` instead.",
+        + "Use `polliwog.transform.apply_transform()` instead.",
         DeprecationWarning,
     )
 

--- a/vg/matrix.py
+++ b/vg/matrix.py
@@ -4,6 +4,9 @@ from ._helpers import raise_dimension_error
 
 def pad_with_ones(matrix):
     """
+    Deprecated. Matrix functions have been moved to polliwog. Will be removed in
+    vg 2.
+
     Add a column of ones. Transform from:
         array([[1., 2., 3.],
                [2., 3., 4.],
@@ -12,8 +15,15 @@ def pad_with_ones(matrix):
         array([[1., 2., 3., 1.],
                [2., 3., 4., 1.],
                [5., 6., 7., 1.]])
-
     """
+    import warnings
+
+    warnings.warn(
+        "`vg.matrix.pad_with_ones()` has been deprecated and will be removed in vg 2. "
+        + "Matrix functions have been moved to polliwog.",
+        DeprecationWarning,
+    )
+
     if matrix.ndim != 2 or matrix.shape[1] != 3:
         raise ValueError("Invalid shape %s: pad expects nx3" % (matrix.shape,))
     return np.pad(matrix, ((0, 0), (0, 1)), mode="constant", constant_values=1)
@@ -21,6 +31,9 @@ def pad_with_ones(matrix):
 
 def unpad(matrix):
     """
+    Deprecated. Matrix functions have been moved to polliwog. Will be removed in
+    vg 2.
+
     Strip off a column (e.g. of ones). Transform from:
         array([[1., 2., 3., 1.],
                [2., 3., 4., 1.],
@@ -29,8 +42,15 @@ def unpad(matrix):
         array([[1., 2., 3.],
                [2., 3., 4.],
                [5., 6., 7.]])
-
     """
+    import warnings
+
+    warnings.warn(
+        "`vg.matrix.unpad()` has been deprecated and will be removed in vg 2. "
+        + "Matrix functions have been moved to polliwog.",
+        DeprecationWarning,
+    )
+
     if matrix.ndim != 2 or matrix.shape[1] != 4:
         raise ValueError("Invalid shape %s: unpad expects nx4" % (matrix.shape,))
     if not all(matrix[:, 3] == 1.0):
@@ -40,9 +60,20 @@ def unpad(matrix):
 
 def transform(vertices, transform):
     """
+    Deprecated. Will be removed in vg 2. Use
+    `polliwog.transform.apply_affine_transform()` instead.
+
     Apply the given transformation matrix to the vertices using homogenous
     coordinates.
     """
+    import warnings
+
+    warnings.warn(
+        "`vg.matrix.transform()` has been deprecated and will be removed in vg 2. "
+        + "Use `polliwog.transform.apply_affine_transform()` instead.",
+        DeprecationWarning,
+    )
+
     if transform.shape != (4, 4):
         raise ValueError("Transformation matrix should be 4x4")
 

--- a/vg/test_matrix_pad_with_ones.py
+++ b/vg/test_matrix_pad_with_ones.py
@@ -4,22 +4,35 @@ from .matrix import pad_with_ones
 
 
 def test_pad_with_ones():
-    np.testing.assert_array_equal(
-        pad_with_ones(np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]])),
-        np.array([[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 1.0]]),
-    )
+    with pytest.deprecated_call():
+        np.testing.assert_array_equal(
+            pad_with_ones(
+                np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]])
+            ),
+            np.array(
+                [[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 1.0]]
+            ),
+        )
 
 
 def test_pad_with_wrong_dimensions():
     # NB: on windows, the sizes here will render as 3L, not 3:
-    with pytest.raises(
-        ValueError, match=r"^Invalid shape \(3L?, 4L?\): pad expects nx3$"
-    ):
-        pad_with_ones(
-            np.array(
-                [[1.0, 2.0, 3.0, 42.0], [2.0, 3.0, 4.0, 42.0], [5.0, 6.0, 7.0, 42.0]]
+    with pytest.deprecated_call():
+        with pytest.raises(
+            ValueError, match=r"^Invalid shape \(3L?, 4L?\): pad expects nx3$"
+        ):
+            pad_with_ones(
+                np.array(
+                    [
+                        [1.0, 2.0, 3.0, 42.0],
+                        [2.0, 3.0, 4.0, 42.0],
+                        [5.0, 6.0, 7.0, 42.0],
+                    ]
+                )
             )
-        )
 
-    with pytest.raises(ValueError, match=r"^Invalid shape \(3L?,\): pad expects nx3$"):
-        pad_with_ones(np.array([1.0, 2.0, 3.0]))
+    with pytest.deprecated_call():
+        with pytest.raises(
+            ValueError, match=r"^Invalid shape \(3L?,\): pad expects nx3$"
+        ):
+            pad_with_ones(np.array([1.0, 2.0, 3.0]))

--- a/vg/test_matrix_transform.py
+++ b/vg/test_matrix_transform.py
@@ -16,19 +16,26 @@ transform = np.array(
 def test_apply_homogeneous():
     point = np.array([5.0, 0.0, 1.0])
     expected_point = np.array([15.0, 0.0, 2.0])
-    np.testing.assert_array_equal(apply_transform(point, transform), expected_point)
+    with pytest.deprecated_call():
+        np.testing.assert_array_equal(apply_transform(point, transform), expected_point)
 
 
 def test_apply_homogeneous_stacked():
     points = np.array([[1.0, 2.0, 3.0], [5.0, 0.0, 1.0]])
     expected_points = np.array([[3.0, 1.0, 6.0], [15.0, 0.0, 2.0]])
-    np.testing.assert_array_equal(apply_transform(points, transform), expected_points)
+    with pytest.deprecated_call():
+        np.testing.assert_array_equal(
+            apply_transform(points, transform), expected_points
+        )
 
 
 def test_apply_homogeneous_error():
-    with pytest.raises(ValueError, match="Transformation matrix should be 4x4"):
-        apply_transform(np.array([1.0, 2.0, 3.0]), np.array([1.0]))
-    with pytest.raises(ValueError, match=r"Vertices should be \(3,\) or Nx3"):
-        apply_transform(np.array([1.0, 2.0]), transform)
-    with pytest.raises(ValueError, match="Not sure what to do with 3 dimensions"):
-        apply_transform(np.array([[[1.0, 2.0, 3.0]]]), transform)
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError, match="Transformation matrix should be 4x4"):
+            apply_transform(np.array([1.0, 2.0, 3.0]), np.array([1.0]))
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError, match=r"Vertices should be \(3,\) or Nx3"):
+            apply_transform(np.array([1.0, 2.0]), transform)
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError, match="Not sure what to do with 3 dimensions"):
+            apply_transform(np.array([[[1.0, 2.0, 3.0]]]), transform)

--- a/vg/test_matrix_unpad.py
+++ b/vg/test_matrix_unpad.py
@@ -4,25 +4,33 @@ from .matrix import unpad
 
 
 def test_unpad():
-    np.testing.assert_array_equal(
-        unpad(
-            np.array([[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 1.0]])
-        ),
-        np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
-    )
+    with pytest.deprecated_call():
+        np.testing.assert_array_equal(
+            unpad(
+                np.array(
+                    [[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 1.0]]
+                )
+            ),
+            np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]),
+        )
 
     # NB: on windows, the sizes here will render as 3L, not 3:
-    with pytest.raises(
-        ValueError, match=r"^Invalid shape \(3L?, 3L?\): unpad expects nx4$"
-    ):
-        unpad(np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]))
+    with pytest.deprecated_call():
+        with pytest.raises(
+            ValueError, match=r"^Invalid shape \(3L?, 3L?\): unpad expects nx4$"
+        ):
+            unpad(np.array([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0], [5.0, 6.0, 7.0]]))
 
-    with pytest.raises(
-        ValueError, match=r"^Invalid shape \(4L?,\): unpad expects nx4$"
-    ):
-        unpad(np.array([1.0, 2.0, 3.0, 4.0]))
+    with pytest.deprecated_call():
+        with pytest.raises(
+            ValueError, match=r"^Invalid shape \(4L?,\): unpad expects nx4$"
+        ):
+            unpad(np.array([1.0, 2.0, 3.0, 4.0]))
 
-    with pytest.raises(ValueError, match="Expected a column of ones"):
-        unpad(
-            np.array([[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 3.0]])
-        )
+    with pytest.deprecated_call():
+        with pytest.raises(ValueError, match="Expected a column of ones"):
+            unpad(
+                np.array(
+                    [[1.0, 2.0, 3.0, 1.0], [2.0, 3.0, 4.0, 1.0], [5.0, 6.0, 7.0, 3.0]]
+                )
+            )


### PR DESCRIPTION
Closes #95

Deprecate `vg.matrix.pad_with_ones()`, `vg.matrix.unpad()`, and `vg.matrix.transform()` in favor of `polliwog.transform.apply_transform()`. (See lace/polliwog#113 for additional context on why `pad_with_ones()` and `unpad()` are being removed.)