### PR TITLE
Fix error in computing angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Compute pairwise angles between two stacks of vectors:
 ```py
 # 😭
 dot_products = np.einsum("ij,ij->i", v1s.reshape(-1, 3), v2s.reshape(-1, 3))
-cosines = dot_products / np.linalg.norm(v1s, axis=1) / np.linalg.norm(v1s, axis=1)
+cosines = dot_products / np.linalg.norm(v1s, axis=1) / np.linalg.norm(v2s, axis=1)
 angles = np.arccos(np.clip(cosines, -1.0, 1.0))
 
 # 🤯


### PR DESCRIPTION
Should divide by v1 and v2 norms, not by v1's norm twice.